### PR TITLE
Raycaster

### DIFF
--- a/labs/raycaster/BUILD
+++ b/labs/raycaster/BUILD
@@ -1,0 +1,24 @@
+load("@rules_qt//:qt.bzl", "qt_cc_binary", "qt_cc_library")
+
+qt_cc_library(
+    name = "raycaster_lib",
+    hdrs = glob(["include/*.h"]),
+    srcs = glob(["src/*.cpp"]),
+    includes = ["include"],  # Указываем директорию с заголовками
+    deps = [
+        "@rules_qt//:qt_core",
+        "@rules_qt//:qt_gui",
+        "@rules_qt//:qt_widgets",
+    ],
+)
+
+qt_cc_binary(
+    name = "raycaster",
+    srcs = ["src/main.cpp"],
+    deps = [
+        ":raycaster_lib",
+        "@rules_qt//:qt_core",
+        "@rules_qt//:qt_gui",
+        "@rules_qt//:qt_widgets",
+    ],
+)

--- a/labs/raycaster/include/controller.h
+++ b/labs/raycaster/include/controller.h
@@ -1,0 +1,80 @@
+#ifndef CONTROLLER_H
+#define CONTROLLER_H
+
+#include <QObject>
+#include <vector>
+#include <QPointF>
+#include <unordered_map>
+#include "polygon.h"
+#include "ray.h"
+
+class Controller : public QObject {
+    Q_OBJECT
+
+public:
+    enum class Mode {
+        POLYGON,
+        LIGHT,
+        STATIC_LIGHTS
+    };
+
+    explicit Controller(QObject *parent = nullptr);
+    ~Controller();
+
+    void setMode(Mode mode);
+    Mode getMode() const;
+    bool isLightMode() const;
+
+    const std::vector<Polygon>& GetPolygons() const;
+    void AddPolygon(const Polygon& polygon);
+    void AddVertexToLastPolygon(const QPointF& new_vertex);
+    void UpdateLastPolygon(const QPointF& new_vertex);
+    void UpdateBoundaryPolygon(const std::vector<QPointF>& vertices);
+    void RemoveLastPolygon();
+
+    const std::vector<LightSource>& GetLightSources() const;
+    void AddLightSource(const QPointF& position, bool isStatic);
+    void RemoveLightSource(size_t index);
+    void UpdateLightSourcePosition(size_t index, const QPointF& newPosition);
+    void UpdateStaticLightRadius(size_t index, double radius);
+
+    bool IsPointInsidePolygon(const QPointF& point) const;
+    bool WouldEdgeIntersect(const QPointF& p1, const QPointF& p2) const;
+
+    std::vector<Ray> CastRays(const LightSource& light);
+    void IntersectRays(std::vector<Ray>* rays, const LightSource& light);
+    void RemoveAdjacentRays(std::vector<Ray>* rays);
+
+    Polygon CreateLightArea(const LightSource& light);
+    void AddExamplePolygons();
+
+    std::vector<QPointF> GetRayIntersections(const QPointF& source) const;
+    std::vector<std::vector<QPointF>> GetSightPolygons(const QPointF& source) const;
+
+    void SetDynamicLightCollisions(bool enabled);
+
+signals:
+    void modeChanged(bool isLightMode);
+
+private:
+    struct VertexData {
+        QPointF point;
+        size_t polygonIndex;
+        size_t vertexIndex;
+    };
+
+    void updateVertexCache();
+    bool doesEdgeIntersectPolygons(const QPointF& p1, const QPointF& p2) const;
+
+    Mode m_mode;
+    std::vector<Polygon> m_polygons;
+    std::vector<LightSource> m_lightSources;
+    std::unordered_map<QPointF, VertexData> m_vertexCache;
+    bool m_cacheValid;
+    bool dynamicLightCollisions;
+
+    static constexpr double ANGLE_OFFSET = 0.0001;
+    static constexpr double ADJACENT_THRESHOLD = 0.01;
+};
+
+#endif

--- a/labs/raycaster/include/controller.h
+++ b/labs/raycaster/include/controller.h
@@ -5,8 +5,21 @@
 #include <vector>
 #include <QPointF>
 #include <unordered_map>
+#include <functional>
+#include "lightsource.h"
 #include "polygon.h"
 #include "ray.h"
+
+namespace std {
+    template <>
+    struct hash<QPointF> {
+        std::size_t operator()(const QPointF& p) const noexcept {
+            std::size_t h1 = std::hash<double>{}(p.x());
+            std::size_t h2 = std::hash<double>{}(p.y());
+            return h1 ^ (h2 << 1);
+        }
+    };
+}
 
 class Controller : public QObject {
     Q_OBJECT
@@ -65,6 +78,7 @@ private:
 
     void updateVertexCache();
     bool doesEdgeIntersectPolygons(const QPointF& p1, const QPointF& p2) const;
+    std::vector<double> calculateAngles(const QPointF& source, const QPointF& vertex) const;
 
     Mode m_mode;
     std::vector<Polygon> m_polygons;
@@ -72,6 +86,7 @@ private:
     std::unordered_map<QPointF, VertexData> m_vertexCache;
     bool m_cacheValid;
     bool dynamicLightCollisions;
+
 
     static constexpr double ANGLE_OFFSET = 0.0001;
     static constexpr double ADJACENT_THRESHOLD = 0.01;

--- a/labs/raycaster/include/drawingarea.h
+++ b/labs/raycaster/include/drawingarea.h
@@ -1,0 +1,59 @@
+#ifndef DRAWINGAREA_H
+#define DRAWINGAREA_H
+
+#include <QWidget>
+#include <QPoint>
+#include <QTimer>
+#include <QPixmap>
+#include <vector>
+#include <QPainter>
+#include <QMouseEvent>
+#include <QSlider>
+#include "controller.h"
+
+class DrawingArea : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit DrawingArea(QWidget *parent = nullptr);
+    ~DrawingArea();
+
+    void setController(Controller* ctrl);
+    void setMode(bool lightMode);
+    void setMode(Controller::Mode newMode);
+    void updateBackgroundCache();
+    void CancelPolygonDrawing();
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+    void mousePressEvent(QMouseEvent* event) override;
+    void mouseMoveEvent(QMouseEvent* event) override;
+    void mouseReleaseEvent(QMouseEvent* event) override;
+    void resizeEvent(QResizeEvent* event) override;
+
+private:
+    void createBoundaryPolygon();
+    void updateLightSource();
+    void drawPolygons(QPainter& painter);
+    void drawLightSource(QPainter& painter);
+    bool hasSelfIntersections(const std::vector<QPointF>& polygon) const;
+    bool polygonsIntersect(const std::vector<QPointF>& poly1, const std::vector<QPointF>& poly2) const;
+    bool doSegmentsIntersect(const QPointF& p1, const QPointF& p2, const QPointF& p3, const QPointF& p4) const;
+    bool isPointInPolygon(const QPointF& point, const std::vector<QPointF>& polygon) const;
+
+    Controller::Mode mode;
+    Controller* controller;
+    bool isDrawingPolygon;
+    QSize lastSize;
+    QPixmap* cachedBackground;
+    QPointF cursorPos;
+    QTimer updateTimer;
+    QSlider* radiusSlider;
+    size_t selectedLightIndex;
+
+private slots:
+    void onRadiusChanged(int value);
+};
+
+#endif

--- a/labs/raycaster/include/lightsource.h
+++ b/labs/raycaster/include/lightsource.h
@@ -1,0 +1,16 @@
+#ifndef LIGHTSOURCE_H
+#define LIGHTSOURCE_H
+
+#include <QPointF>
+#include <QColor>
+#include <QGradient>
+
+struct LightSource {
+    QPointF position;
+    QColor color;
+    double radius;
+    bool isStatic;
+    QRadialGradient gradient;
+};
+
+#endif

--- a/labs/raycaster/include/mainwindow.h
+++ b/labs/raycaster/include/mainwindow.h
@@ -1,0 +1,51 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include <QPushButton>
+#include <QHBoxLayout>
+#include <QVBoxLayout>
+#include <QWidget>
+#include <QCheckBox>
+#include "drawingarea.h"
+#include "controller.h"
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow();
+
+private slots:
+    void onPolygonModeClicked();
+    void onLightModeClicked();
+    void onStaticLightsModeClicked();
+    void onClearPolygonsClicked();
+    void onClearStaticLightsClicked();
+    void onDynamicLightCollisionsChanged(int state);
+
+private:
+    void setupUI();
+    void createModeButtons();
+    void createUtilityButtons();
+
+    DrawingArea* drawingArea;
+    Controller* controller;
+    
+    QPushButton* polygonModeButton;
+    QPushButton* lightModeButton;
+    QPushButton* staticLightsModeButton;
+    
+    QPushButton* clearPolygonsButton;
+    QPushButton* clearStaticLightsButton;
+    QCheckBox* dynamicLightCollisionsCheckbox;
+    
+    QVBoxLayout* mainLayout;
+    QHBoxLayout* modeButtonsLayout;
+    QHBoxLayout* utilityButtonsLayout;
+    QWidget* centralWidget;
+};
+
+#endif

--- a/labs/raycaster/include/polygon.h
+++ b/labs/raycaster/include/polygon.h
@@ -1,0 +1,90 @@
+#ifndef POLYGON_H
+#define POLYGON_H
+
+#include <vector>
+#include <optional>
+#include <QPointF>
+#include <cmath>
+#include "ray.h"
+
+class Polygon {
+public:
+    explicit Polygon(const std::vector<QPointF>& vertices)
+        : m_vertices(vertices)
+    {}
+
+    const std::vector<QPointF>& getVertices() const { return m_vertices; }
+    
+    void AddVertex(const QPointF& vertex) {
+        m_vertices.push_back(vertex);
+    }
+
+    void UpdateLastVertex(const QPointF& new_vertex) {
+        if (!m_vertices.empty()) {
+            m_vertices.back() = new_vertex;
+        }
+    }
+
+    std::optional<QPointF> IntersectRay(const Ray& ray) const {
+        if (m_vertices.size() < 2) return std::nullopt;
+        QPointF p = ray.getBegin();
+        QPointF r = ray.getEnd() - ray.getBegin();
+        bool found = false;
+        QPointF closestIntersection;
+        double minT = std::numeric_limits<double>::max();
+        for (size_t i = 0; i < m_vertices.size(); ++i) {
+            QPointF a = m_vertices[i];
+            QPointF b = m_vertices[(i + 1) % m_vertices.size()];
+            QPointF s = b - a;
+            double rxs = r.x() * s.y() - r.y() * s.x();
+            if (std::fabs(rxs) < 1e-9) continue;
+            QPointF diff = a - p;
+            double t = (diff.x() * s.y() - diff.y() * s.x()) / rxs;
+            double u = (diff.x() * r.y() - diff.y() * r.x()) / rxs;
+            if (t >= 0 && u >= 0 && u <= 1.0) {
+                if (t < minT) {
+                    minT = t;
+                    closestIntersection = QPointF(p.x() + t * r.x(), p.y() + t * r.y());
+                    found = true;
+                }
+            }
+        }
+        return found ? std::optional<QPointF>(closestIntersection) : std::nullopt;
+    }
+
+    bool IsPointInside(const QPointF& point) const {
+        if (m_vertices.size() < 3) return false;
+
+        bool inside = false;
+        for (size_t i = 0, j = m_vertices.size() - 1; i < m_vertices.size(); j = i++) {
+            if (((m_vertices[i].y() > point.y()) != (m_vertices[j].y() > point.y())) &&
+                (point.x() < (m_vertices[j].x() - m_vertices[i].x()) * (point.y() - m_vertices[i].y()) / 
+                (m_vertices[j].y() - m_vertices[i].y()) + m_vertices[i].x())) {
+                inside = !inside;
+            }
+        }
+        return inside;
+    }
+
+    bool DoesEdgeIntersect(const QPointF& p1, const QPointF& p2) const {
+        QPointF r = p2 - p1;
+        for (size_t i = 0; i < m_vertices.size(); ++i) {
+            QPointF a = m_vertices[i];
+            QPointF b = m_vertices[(i + 1) % m_vertices.size()];
+            QPointF s = b - a;
+            double rxs = r.x() * s.y() - r.y() * s.x();
+            if (std::fabs(rxs) < 1e-9) continue;
+            QPointF diff = a - p1;
+            double t = (diff.x() * s.y() - diff.y() * s.x()) / rxs;
+            double u = (diff.x() * r.y() - diff.y() * r.x()) / rxs;
+            if (t > 1e-9 && t < 1 - 1e-9 && u > 1e-9 && u < 1 - 1e-9)
+                return true;
+        }
+        return false;
+    }
+
+private:
+    std::vector<QPointF> m_vertices;
+};
+
+#endif

--- a/labs/raycaster/include/ray.h
+++ b/labs/raycaster/include/ray.h
@@ -1,0 +1,41 @@
+#ifndef RAY_H
+#define RAY_H
+
+#include <QPointF>
+#include <cmath>
+
+class Ray {
+public:
+    Ray(const QPointF& begin, const QPointF& end, double angle)
+        : m_begin(begin)
+        , m_end(end)
+        , m_angle(angle)
+    {}
+
+    const QPointF& getBegin() const { return m_begin; }
+    const QPointF& getEnd() const { return m_end; }
+    double getAngle() const { return m_angle; }
+
+    void setBegin(const QPointF& begin) { m_begin = begin; }
+    void setEnd(const QPointF& end) { m_end = end; }
+    void setAngle(double angle) { m_angle = angle; }
+
+    Ray Rotate(double angle) const {
+        double newAngle = m_angle + angle;
+        double dx = m_end.x() - m_begin.x();
+        double dy = m_end.y() - m_begin.y();
+        double length = std::sqrt(dx*dx + dy*dy);
+        QPointF newEnd(
+            m_begin.x() + length * std::cos(newAngle),
+            m_begin.y() + length * std::sin(newAngle)
+        );
+        return Ray(m_begin, newEnd, newAngle);
+    }
+
+private:
+    QPointF m_begin;
+    QPointF m_end;
+    double m_angle;
+};
+
+#endif

--- a/labs/raycaster/src/controller.cpp
+++ b/labs/raycaster/src/controller.cpp
@@ -1,0 +1,411 @@
+#include "controller.h"
+#include <QDebug>
+#include <set>
+#include <functional>
+#include <QRadialGradient>
+#include <cmath>
+
+Controller::Controller(QObject *parent)
+    : QObject(parent)
+    , m_mode(Mode::LIGHT)
+    , m_cacheValid(false)
+    , dynamicLightCollisions(true)
+{
+    LightSource mainLight;
+    mainLight.position = QPointF(400, 300);
+    mainLight.color = QColor(255, 255, 255, 255);
+    mainLight.radius = -1;
+    mainLight.isStatic = false;
+    m_lightSources.push_back(mainLight);
+}
+
+Controller::~Controller()
+{
+}
+
+void Controller::setMode(Mode mode)
+{
+    m_mode = mode;
+    emit modeChanged(mode == Mode::LIGHT || mode == Mode::STATIC_LIGHTS);
+}
+
+Controller::Mode Controller::getMode() const
+{
+    return m_mode;
+}
+
+bool Controller::isLightMode() const
+{
+    return m_mode == Mode::LIGHT || m_mode == Mode::STATIC_LIGHTS;
+}
+
+const std::vector<Polygon>& Controller::GetPolygons() const {
+    return m_polygons;
+}
+
+void Controller::AddPolygon(const Polygon& polygon) {
+    qDebug() << "add polygon " << polygon.getVertices();
+    m_polygons.push_back(polygon);
+    m_cacheValid = false;
+}
+
+void Controller::AddVertexToLastPolygon(const QPointF& new_vertex) {
+    if (!m_polygons.empty()) {
+        m_polygons.back().AddVertex(new_vertex);
+        m_cacheValid = false;
+    }
+}
+
+void Controller::UpdateLastPolygon(const QPointF& new_vertex) {
+    if (!m_polygons.empty()) {
+        m_polygons.back().UpdateLastVertex(new_vertex);
+        m_cacheValid = false;
+    }
+}
+
+void Controller::UpdateBoundaryPolygon(const std::vector<QPointF>& vertices) {
+    if (!m_polygons.empty()) {
+        m_polygons[0] = Polygon(vertices);
+    }
+}
+
+void Controller::RemoveLastPolygon() {
+    if (!m_polygons.empty()) {
+        m_polygons.pop_back();
+        m_cacheValid = false;
+    }
+}
+
+const std::vector<LightSource>& Controller::GetLightSources() const {
+    return m_lightSources;
+}
+
+void Controller::AddLightSource(const QPointF& position, bool isStatic)
+{
+    LightSource newLight;
+    newLight.position = position;
+    newLight.isStatic = isStatic;
+    if (isStatic) {
+        newLight.color = QColor(100, 150, 255, 150);
+        newLight.radius = 350.0;
+    } else {
+        newLight.color = QColor(255, 255, 255, 255);
+        newLight.radius = -1;
+    }
+    m_lightSources.push_back(newLight);
+}
+
+void Controller::RemoveLightSource(size_t index) {
+    if (index < m_lightSources.size()) {
+        m_lightSources.erase(m_lightSources.begin() + index);
+    }
+}
+
+void Controller::UpdateLightSourcePosition(size_t index, const QPointF& newPosition)
+{
+    if (index < m_lightSources.size())
+    {
+        if (index == 0 && dynamicLightCollisions) {
+            const int numSources = 10;
+            const double radius = 4.0;
+            const double circleRadius = 15.0;
+            auto pointDistance = [](const QPointF& a, const QPointF& b) {
+                double dx = a.x() - b.x();
+                double dy = a.y() - b.y();
+                return std::sqrt(dx*dx + dy*dy);
+            };
+            if (IsPointInsidePolygon(m_lightSources[0].position))
+                return;
+            if (IsPointInsidePolygon(newPosition))
+                return;
+            for (int i = 0; i < numSources; ++i) {
+                double angle = 2 * M_PI * i / numSources;
+                QPointF ballCenter(newPosition.x() + circleRadius * std::cos(angle),
+                                   newPosition.y() + circleRadius * std::sin(angle));
+                for (int j = 0; j < 4; ++j) {
+                    double ballAngle = 2 * M_PI * j / 4;
+                    QPointF point(ballCenter.x() + radius * std::cos(ballAngle),
+                                  ballCenter.y() + radius * std::sin(ballAngle));
+                    if (IsPointInsidePolygon(point))
+                        return;
+                }
+            }
+        }
+        if (m_polygons.empty() || m_polygons[0].IsPointInside(newPosition))
+        {
+            m_lightSources[index].position = newPosition;
+        }
+    }
+}
+
+void Controller::UpdateStaticLightRadius(size_t index, double radius)
+{
+    if (index < m_lightSources.size() && m_lightSources[index].isStatic)
+    {
+        m_lightSources[index].radius = radius;
+        m_cacheValid = false;
+    }
+}
+
+bool Controller::IsPointInsidePolygon(const QPointF& point) const {
+    for (size_t i = 1; i < m_polygons.size(); ++i) {
+        const auto& vertices = m_polygons[i].getVertices();
+        if (vertices.size() < 3) continue;
+        bool inside = false;
+        for (size_t i = 0, j = vertices.size() - 1; i < vertices.size(); j = i++) {
+            if (((vertices[i].y() > point.y()) != (vertices[j].y() > point.y())) &&
+                (point.x() < (vertices[j].x() - vertices[i].x()) * (point.y() - vertices[i].y()) /
+                (vertices[j].y() - vertices[i].y()) + vertices[i].x())) {
+                inside = !inside;
+            }
+        }
+        if (inside) return true;
+    }
+    return false;
+}
+
+bool Controller::WouldEdgeIntersect(const QPointF& p1, const QPointF& p2) const
+{
+    return doesEdgeIntersectPolygons(p1, p2);
+}
+
+void Controller::updateVertexCache()
+{
+    m_vertexCache.clear();
+    for (size_t polyIndex = 0; polyIndex < m_polygons.size(); ++polyIndex) {
+        const auto& vertices = m_polygons[polyIndex].getVertices();
+        for (size_t vertexIndex = 0; vertexIndex < vertices.size(); ++vertexIndex) {
+            const QPointF& vertex = vertices[vertexIndex];
+            if (m_vertexCache.find(vertex) == m_vertexCache.end()) {
+                VertexData data;
+                data.point = vertex;
+                data.polygonIndex = polyIndex;
+                data.vertexIndex = vertexIndex;
+                m_vertexCache[vertex] = data;
+            }
+        }
+    }
+    m_cacheValid = true;
+}
+
+std::vector<double> Controller::calculateAngles(const QPointF& source, const QPointF& vertex) const
+{
+    double baseAngle = std::atan2(vertex.y() - source.y(), vertex.x() - source.x());
+    return {
+        baseAngle - ANGLE_OFFSET,
+        baseAngle,
+        baseAngle + ANGLE_OFFSET
+    };
+}
+
+std::vector<Ray> Controller::CastRays(const LightSource& light)
+{
+    if (!m_cacheValid) {
+        updateVertexCache();
+    }
+    std::vector<Ray> rays;
+    rays.reserve(m_vertexCache.size() * 3);
+    for (const auto& [vertex, data] : m_vertexCache) {
+        if (data.polygonIndex == 0) continue;
+        double dx = light.position.x() - vertex.x();
+        double dy = light.position.y() - vertex.y();
+        double distance = std::sqrt(dx*dx + dy*dy);
+        if (light.radius > 0 && distance > light.radius)
+            continue;
+        auto angles = calculateAngles(light.position, vertex);
+        for (double angle : angles) {
+            QPointF direction(std::cos(angle), std::sin(angle));
+            double rayLength = light.isStatic ? light.radius : 10000.0;
+            QPointF end(light.position.x() + direction.x() * rayLength, 
+                        light.position.y() + direction.y() * rayLength);
+            rays.emplace_back(light.position, end, angle);
+        }
+    }
+    return rays;
+}
+
+void Controller::IntersectRays(std::vector<Ray>* rays, const LightSource& light)
+{
+    if (!rays) return;
+    auto distanceBetween = [](const QPointF& a, const QPointF& b) {
+        double dx = a.x() - b.x();
+        double dy = a.y() - b.y();
+        return std::sqrt(dx*dx + dy*dy);
+    };
+    for (size_t i = 0; i < rays->size(); ++i) {
+        Ray& ray = (*rays)[i];
+        double minDistance = distanceBetween(ray.getBegin(), ray.getEnd());
+        QPointF closestIntersection = ray.getEnd();
+        for (const auto& polygon : m_polygons) {
+            auto intersection = polygon.IntersectRay(ray);
+            if (intersection) {
+                double d = distanceBetween(ray.getBegin(), *intersection);
+                if (d < minDistance) {
+                    minDistance = d;
+                    closestIntersection = *intersection;
+                }
+            }
+        }
+        if (closestIntersection != ray.getEnd()) {
+            ray.setEnd(closestIntersection);
+        }
+    }
+}
+
+void Controller::RemoveAdjacentRays(std::vector<Ray>* rays)
+{
+    if (!rays || rays->empty()) return;
+    std::sort(rays->begin(), rays->end(), 
+        [](const Ray& a, const Ray& b) {
+            return a.getAngle() < b.getAngle();
+        });
+    std::set<QPointF, std::function<bool(const QPointF&, const QPointF&)>> uniqueEndpoints(
+        [](const QPointF& a, const QPointF& b) {
+            double dx = a.x() - b.x();
+            double dy = a.y() - b.y();
+            return std::sqrt(dx*dx + dy*dy) > ADJACENT_THRESHOLD;
+        }
+    );
+    std::vector<Ray> filteredRays;
+    filteredRays.reserve(rays->size());
+    for (const auto& ray : *rays) {
+        if (uniqueEndpoints.insert(ray.getEnd()).second) {
+            filteredRays.push_back(ray);
+        }
+    }
+    *rays = std::move(filteredRays);
+}
+
+Polygon Controller::CreateLightArea(const LightSource& light) {
+    if (light.isStatic) {
+        std::vector<QPointF> vertices;
+        const int numPoints = 36;
+        for (int i = 0; i < numPoints; ++i) {
+            double angle = 2 * M_PI * i / numPoints;
+            QPointF point(
+                light.position.x() + light.radius * std::cos(angle),
+                light.position.y() + light.radius * std::sin(angle)
+            );
+            vertices.push_back(point);
+        }
+        return Polygon(vertices);
+    } else {
+        std::vector<Ray> rays = CastRays(light);
+        IntersectRays(&rays, light);
+        RemoveAdjacentRays(&rays);
+        std::vector<QPointF> vertices;
+        vertices.reserve(rays.size());
+        for (const auto& ray : rays) {
+            vertices.push_back(ray.getEnd());
+        }
+        return Polygon(vertices);
+    }
+}
+
+void Controller::AddExamplePolygons() {
+    m_polygons.push_back(Polygon({QPointF(111,104), QPointF(153,188), QPointF(221,105)}));
+    m_polygons.push_back(Polygon({QPointF(556,98), QPointF(541,167), QPointF(602,132), QPointF(634,60)}));
+    m_polygons.push_back(Polygon({QPointF(245,268), QPointF(263,416), QPointF(452,481), QPointF(456,356)}));
+    m_polygons.push_back(Polygon({QPointF(544,273), QPointF(573,402), QPointF(720,234), QPointF(608,229)}));
+    m_polygons.push_back(Polygon({QPointF(107,270), QPointF(77,407), QPointF(160,354)}));
+}
+
+std::vector<QPointF> Controller::GetRayIntersections(const QPointF& source) const
+{
+    struct Intersection {
+        QPointF point;
+        double angle;
+        double param;
+    };
+    std::vector<Intersection> intersections;
+    const double angleOffset = 0.00001;
+    std::vector<QPointF> uniqueVertices;
+    for (const auto& polygon : m_polygons) {
+        for (const auto& vertex : polygon.getVertices()) {
+            QString key = QString("%1,%2").arg(vertex.x()).arg(vertex.y());
+            bool isUnique = true;
+            for (const auto& existing : uniqueVertices) {
+                if (QString("%1,%2").arg(existing.x()).arg(existing.y()) == key) {
+                    isUnique = false;
+                    break;
+                }
+            }
+            if (isUnique)
+                uniqueVertices.push_back(vertex);
+        }
+    }
+    std::vector<double> uniqueAngles;
+    for (const auto& vertex : uniqueVertices) {
+        double angle = std::atan2(vertex.y() - source.y(), vertex.x() - source.x());
+        uniqueAngles.push_back(angle - angleOffset);
+        uniqueAngles.push_back(angle);
+        uniqueAngles.push_back(angle + angleOffset);
+    }
+    auto distanceBetween = [](const QPointF& a, const QPointF& b) {
+        double dx = a.x() - b.x();
+        double dy = a.y() - b.y();
+        return std::sqrt(dx*dx + dy*dy);
+    };
+    for (double angle : uniqueAngles) {
+        QPointF direction(std::cos(angle), std::sin(angle));
+        QPointF end(source.x() + direction.x() * 10000.0, 
+                    source.y() + direction.y() * 10000.0);
+        Ray ray(source, end, angle);
+        QPointF closestIntersection;
+        double minDistance = std::numeric_limits<double>::max();
+        bool hasIntersection = false;
+        for (const auto& polygon : m_polygons) {
+            auto intersection = polygon.IntersectRay(ray);
+            if (intersection) {
+                double d = distanceBetween(source, *intersection);
+                if (d < minDistance) {
+                    minDistance = d;
+                    closestIntersection = *intersection;
+                    hasIntersection = true;
+                }
+            }
+        }
+        if (hasIntersection) {
+            intersections.push_back({closestIntersection, angle, minDistance});
+        }
+    }
+    std::sort(intersections.begin(), intersections.end(),
+        [](const auto& a, const auto& b) { return a.angle < b.angle; });
+    std::vector<QPointF> result;
+    for (const auto& intersection : intersections) {
+        result.push_back(intersection.point);
+    }
+    return result;
+}
+
+std::vector<std::vector<QPointF>> Controller::GetSightPolygons(const QPointF& source) const
+{
+    const int numRays = 8;
+    const double fuzzyRadius = 20.0;
+    std::vector<std::vector<QPointF>> result;
+    result.push_back(GetRayIntersections(source));
+    for (int i = 0; i < numRays; ++i) {
+        double angle = i * (2 * M_PI / numRays);
+        QPointF offset(
+            source.x() + fuzzyRadius * std::cos(angle),
+            source.y() + fuzzyRadius * std::sin(angle)
+        );
+        result.push_back(GetRayIntersections(offset));
+    }
+    return result;
+}
+
+void Controller::SetDynamicLightCollisions(bool enabled)
+{
+    dynamicLightCollisions = enabled;
+}
+
+bool Controller::doesEdgeIntersectPolygons(const QPointF& p1, const QPointF& p2) const
+{
+    for (size_t i = 1; i < m_polygons.size(); ++i) {
+        if (m_polygons[i].DoesEdgeIntersect(p1, p2)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/labs/raycaster/src/drawingarea.cpp
+++ b/labs/raycaster/src/drawingarea.cpp
@@ -1,0 +1,512 @@
+#include "drawingarea.h"
+#include <QPainter>
+#include <QPainterPath>
+#include <QMouseEvent>
+#include <QResizeEvent>
+#include <QDebug>
+#include <QTimer>
+#include <QMessageBox>
+#include <QSlider>
+#include <QPushButton>
+#include <QCheckBox>
+
+DrawingArea::DrawingArea(QWidget *parent)
+    : QWidget(parent)
+    , mode(Controller::Mode::LIGHT)
+    , controller(nullptr)
+    , isDrawingPolygon(false)
+    , lastSize(size())
+    , cachedBackground(nullptr)
+    , cursorPos(0, 0)
+    , selectedLightIndex(0)
+{
+    setMouseTracking(true);
+    setAttribute(Qt::WA_OpaquePaintEvent);
+    setAttribute(Qt::WA_NoSystemBackground);
+    radiusSlider = new QSlider(Qt::Horizontal, this);
+    radiusSlider->setRange(50, 700);
+    radiusSlider->setValue(350);
+    radiusSlider->setFixedWidth(200);
+    radiusSlider->move(10, 10);
+    radiusSlider->hide();
+    connect(radiusSlider, &QSlider::valueChanged, this, &DrawingArea::onRadiusChanged);
+    updateTimer.setInterval(8);
+    connect(&updateTimer, &QTimer::timeout, this, [this]() {
+        update();
+    });
+    updateTimer.start();
+}
+
+DrawingArea::~DrawingArea()
+{
+    delete cachedBackground;
+}
+
+void DrawingArea::setController(Controller* ctrl)
+{
+    controller = ctrl;
+    createBoundaryPolygon();
+}
+
+void DrawingArea::setMode(bool lightMode)
+{
+    setMode(lightMode ? Controller::Mode::LIGHT : Controller::Mode::POLYGON);
+}
+
+void DrawingArea::setMode(Controller::Mode newMode)
+{
+    if (mode == Controller::Mode::POLYGON && newMode != Controller::Mode::POLYGON && isDrawingPolygon) {
+        isDrawingPolygon = false;
+        controller->RemoveLastPolygon();
+    }
+    mode = newMode;
+    radiusSlider->setVisible(mode == Controller::Mode::STATIC_LIGHTS);
+    update();
+}
+
+void DrawingArea::createBoundaryPolygon()
+{
+    if (!controller) return;
+    std::vector<QPointF> boundaryVertices = {
+        QPointF(0, 0),
+        QPointF(width(), 0),
+        QPointF(width(), height()),
+        QPointF(0, height())
+    };
+    controller->AddPolygon(Polygon(boundaryVertices));
+    lastSize = size();
+}
+
+void DrawingArea::resizeEvent(QResizeEvent *event)
+{
+    QWidget::resizeEvent(event);
+    if (!controller) return;
+    std::vector<QPointF> boundary = {
+        QPointF(0, 0),
+        QPointF(width(), 0),
+        QPointF(width(), height()),
+        QPointF(0, height())
+    };
+    if (controller->GetPolygons().empty()) {
+        controller->AddPolygon(Polygon(boundary));
+    } else {
+        controller->UpdateBoundaryPolygon(boundary);
+    }
+    delete cachedBackground;
+    cachedBackground = new QPixmap(size());
+    updateBackgroundCache();
+    lastSize = size();
+    update();
+}
+
+void DrawingArea::updateBackgroundCache()
+{
+    if (!controller || !cachedBackground) return;
+    cachedBackground->fill(Qt::black);
+    QPainter painter(cachedBackground);
+    painter.setRenderHint(QPainter::Antialiasing);
+    painter.setPen(QPen(Qt::white, 2));
+    for (const auto& polygon : controller->GetPolygons()) {
+        const auto& vertices = polygon.getVertices();
+        painter.drawPolygon(vertices.data(), vertices.size());
+    }
+}
+
+void DrawingArea::updateLightSource()
+{
+}
+
+void DrawingArea::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+    if (cachedBackground) {
+        painter.drawPixmap(0, 0, *cachedBackground);
+    }
+    if (mode == Controller::Mode::LIGHT || mode == Controller::Mode::STATIC_LIGHTS) {
+        for (const auto& light : controller->GetLightSources()) {
+            auto sightPolygons = controller->GetSightPolygons(light.position);
+            if (!sightPolygons.empty()) {
+                if (!light.isStatic) {
+                    for (size_t i = 1; i < sightPolygons.size(); ++i) {
+                        QPolygonF offsetPolygon;
+                        for (const auto& point : sightPolygons[i]) {
+                            offsetPolygon << point;
+                        }
+                        QPainterPath path;
+                        path.addPolygon(offsetPolygon);
+                        painter.fillPath(path, QColor(255, 255, 255, 20));
+                    }
+                }
+                QPolygonF mainPolygon;
+                for (const auto& point : sightPolygons[0]) {
+                    mainPolygon << point;
+                }
+                QPainterPath mainPath;
+                mainPath.addPolygon(mainPolygon);
+                QRadialGradient gradient(light.position, light.isStatic ? light.radius : 300.0);
+                if (light.isStatic) {
+                    gradient.setColorAt(0.0, QColor(100, 150, 255, 180));
+                    gradient.setColorAt(1.0, QColor(100, 150, 255, 0));
+                } else {
+                    gradient.setColorAt(0.0, QColor(255, 255, 200, 180));
+                    gradient.setColorAt(1.0, QColor(255, 255, 200, 0));
+                }
+                painter.fillPath(mainPath, gradient);
+            }
+            painter.setPen(Qt::NoPen);
+            if (light.isStatic) {
+                painter.setBrush(QColor(56, 128, 221));
+                const int numSources = 5;
+                const double radius = 3.0;
+                const double circleRadius = 3.0;
+                for (int i = 0; i < numSources - 1; ++i) {
+                    double angle = i * (2 * M_PI / (numSources - 1));
+                    QPointF offset(
+                        light.position.x() + circleRadius * std::cos(angle),
+                        light.position.y() + circleRadius * std::sin(angle)
+                    );
+                    painter.drawEllipse(offset, radius, radius);
+                }
+                painter.drawEllipse(light.position, radius, radius);
+            } else {
+                const int numSources = 11;
+                const double radius = 2.0;
+                const double circleRadius = 15.0;
+                QRadialGradient dotGradient(light.position, circleRadius);
+                dotGradient.setColorAt(0, QColor(255, 255, 255, 200));
+                dotGradient.setColorAt(1, QColor(255, 255, 255, 0));
+                painter.setBrush(dotGradient);
+                painter.drawEllipse(light.position, circleRadius, circleRadius);
+                painter.setBrush(QColor(221, 56, 56));
+                painter.drawEllipse(light.position, radius, radius);
+                for (int i = 0; i < numSources - 1; ++i) {
+                    double angle = i * (2 * M_PI / (numSources - 1));
+                    QPointF offset(
+                        light.position.x() + circleRadius * std::cos(angle),
+                        light.position.y() + circleRadius * std::sin(angle)
+                    );
+                    painter.drawEllipse(offset, radius, radius);
+                }
+            }
+        }
+    } else if (mode == Controller::Mode::POLYGON && isDrawingPolygon) {
+        const auto& currentPolygon = controller->GetPolygons().back();
+        const auto& vertices = currentPolygon.getVertices();
+        if (!vertices.empty()) {
+            painter.setPen(Qt::NoPen);
+            painter.setBrush(Qt::white);
+            for (const auto& vertex : vertices) {
+                painter.drawEllipse(vertex, 4, 4);
+            }
+            painter.setPen(QPen(Qt::white, 2));
+            for (size_t i = 0; i < vertices.size() - 1; ++i) {
+                painter.drawLine(vertices[i], vertices[i + 1]);
+            }
+            {
+                QPointF intersectionPoint;
+                bool intersect = false;
+                const auto& polygons = controller->GetPolygons();
+                for (const auto& polygon : polygons) {
+                    const auto& polyVertices = polygon.getVertices();
+                    for (size_t i = 0; i < polyVertices.size(); ++i) {
+                        QPointF current = polyVertices[i];
+                        QPointF next = polyVertices[(i + 1) % polyVertices.size()];
+                        QLineF edge(current, next);
+                        if (QLineF(vertices.back(), cursorPos).intersects(edge, &intersectionPoint) == QLineF::BoundedIntersection) {
+                            if (QLineF(intersectionPoint, current).length() > 0.001 &&
+                                QLineF(intersectionPoint, next).length() > 0.001) {
+                                intersect = true;
+                                break;
+                            }
+                        }
+                    }
+                    if (intersect) break;
+                }
+                QPen previewPen(intersect ? Qt::red : Qt::white, 2);
+                painter.setPen(previewPen);
+                painter.drawLine(vertices.back(), cursorPos);
+                if (intersect) {
+                    painter.setPen(Qt::NoPen);
+                    painter.setBrush(Qt::red);
+                    painter.drawEllipse(intersectionPoint, 4, 4);
+                }
+            }
+            if (vertices.size() >= 2) {
+                QLineF closingLine(cursorPos, vertices.front());
+                bool closeIntersect = false;
+                QPointF interValid;
+                const double eps = 0.001;
+                const auto& polygons = controller->GetPolygons();
+                for (size_t i = 1; i < polygons.size() && !closeIntersect; ++i) {
+                    const auto& polyVertices = polygons[i].getVertices();
+                    for (size_t j = 0; j < polyVertices.size(); ++j) {
+                        QPointF current = polyVertices[j];
+                        QPointF next = polyVertices[(j + 1) % polyVertices.size()];
+                        QLineF edge(current, next);
+                        QPointF tempInter;
+                        if (closingLine.intersects(edge, &tempInter) == QLineF::BoundedIntersection) {
+                            if (QLineF(tempInter, cursorPos).length() < eps ||
+                                QLineF(tempInter, vertices.front()).length() < eps) {
+                                continue;
+                            }
+                            closeIntersect = true;
+                            interValid = tempInter;
+                            break;
+                        }
+                    }
+                }
+                QPen dashedPen(closeIntersect ? Qt::red : Qt::white, 2, Qt::DashLine);
+                painter.setPen(dashedPen);
+                painter.drawLine(cursorPos, vertices.front());
+                if (closeIntersect) {
+                    painter.setPen(Qt::NoPen);
+                    painter.setBrush(Qt::red);
+                    painter.drawEllipse(interValid, 4, 4);
+                }
+            }
+        } else {
+            painter.setPen(Qt::NoPen);
+            painter.setBrush(Qt::white);
+            painter.drawEllipse(cursorPos, 4, 4);
+        }
+    }
+}
+
+void DrawingArea::drawPolygons(QPainter& painter)
+{
+    if (!controller) return;
+    if (mode == Controller::Mode::LIGHT) {
+        for (const auto& light : controller->GetLightSources()) {
+            Polygon lightArea = controller->CreateLightArea(light);
+            painter.setPen(Qt::NoPen);
+            painter.setBrush(light.color);
+            const auto& vertices = lightArea.getVertices();
+            if (vertices.size() >= 3) {
+                QPolygonF polygon;
+                for (const auto& vertex : vertices) {
+                    polygon << vertex;
+                }
+                painter.drawPolygon(polygon);
+            }
+        }
+    }
+    painter.setPen(QPen(Qt::black, 2));
+    painter.setBrush(Qt::transparent);
+    for (const auto& polygon : controller->GetPolygons()) {
+        const auto& vertices = polygon.getVertices();
+        if (vertices.empty()) continue;
+        for (size_t i = 0; i < vertices.size(); ++i) {
+            const auto& current = vertices[i];
+            const auto& next = vertices[(i + 1) % vertices.size()];
+            painter.drawLine(current.toPoint(), next.toPoint());
+        }
+        painter.setPen(QPen(Qt::blue, 2));
+        for (const auto& vertex : vertices) {
+            painter.drawEllipse(vertex.toPoint(), 4, 4);
+        }
+        painter.setPen(QPen(Qt::black, 2));
+    }
+}
+
+void DrawingArea::drawLightSource(QPainter& painter)
+{
+    for (size_t i = 0; i < controller->GetLightSources().size(); ++i) {
+        const auto& light = controller->GetLightSources()[i];
+        painter.setPen(QPen(light.isStatic ? Qt::blue : Qt::red, 2));
+        painter.setBrush(light.isStatic ? Qt::blue : Qt::red);
+        painter.drawEllipse(light.position.toPoint(), 6, 6);
+        if (light.radius > 0) {
+            painter.setPen(QPen(Qt::gray, 1, Qt::DashLine));
+            painter.setBrush(Qt::NoBrush);
+            int radius = static_cast<int>(light.radius);
+            painter.drawEllipse(light.position.toPoint(), radius, radius);
+        }
+    }
+}
+
+void DrawingArea::mousePressEvent(QMouseEvent* event)
+{
+    if (!controller) return;
+    QPointF pos = event->pos();
+    if (mode == Controller::Mode::POLYGON) {
+        if (event->button() == Qt::LeftButton) {
+            if (!isDrawingPolygon) {
+                isDrawingPolygon = true;
+                controller->AddPolygon(Polygon({pos}));
+            } else {
+                const auto& currentPolygon = controller->GetPolygons().back();
+                const auto& vertices = currentPolygon.getVertices();
+                if (!vertices.empty()) {
+                    const QPointF& lastVertex = vertices.back();
+                    if (controller->WouldEdgeIntersect(lastVertex, pos)) {
+                        QMessageBox::warning(this, "Invalid Edge", "The new edge would intersect with an existing polygon");
+                        return;
+                    }
+                }
+                controller->AddVertexToLastPolygon(pos);
+            }
+        } else if (event->button() == Qt::RightButton && isDrawingPolygon) {
+            const auto& currentPolygon = controller->GetPolygons().back();
+            const auto& vertices = currentPolygon.getVertices();
+            isDrawingPolygon = false;
+            if (vertices.size() >= 3) {
+                const QPointF& firstVertex = vertices.front();
+                const QPointF& lastVertex = vertices.back();
+                if (!controller->WouldEdgeIntersect(lastVertex, firstVertex)) {
+                    controller->AddVertexToLastPolygon(firstVertex);
+                    updateBackgroundCache();
+                } else {
+                    QMessageBox::warning(this, "Invalid Edge", "Cannot close the polygon - the closing edge would intersect with an existing polygon");
+                    controller->RemoveLastPolygon();
+                    return;
+                }
+            } else {
+                controller->RemoveLastPolygon();
+            }
+            controller->AddPolygon(Polygon({}));
+        }
+    } else if (mode == Controller::Mode::LIGHT) {
+        controller->UpdateLightSourcePosition(0, pos);
+    } else if (mode == Controller::Mode::STATIC_LIGHTS) {
+        if (event->button() == Qt::LeftButton) {
+            controller->AddLightSource(pos, true);
+            selectedLightIndex = controller->GetLightSources().size() - 1;
+            radiusSlider->setValue(controller->GetLightSources().back().radius);
+        } else if (event->button() == Qt::RightButton) {
+            for (size_t i = 0; i < controller->GetLightSources().size(); ++i) {
+                const auto& light = controller->GetLightSources()[i];
+                if (light.isStatic) {
+                    double distance = QLineF(light.position, pos).length();
+                    if (distance <= 10) {
+                        selectedLightIndex = i;
+                        radiusSlider->setValue(light.radius);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    update();
+}
+
+void DrawingArea::mouseMoveEvent(QMouseEvent *event)
+{
+    if (!controller) return;
+    QPointF pos(event->pos());
+    cursorPos = pos;
+    switch (mode) {
+        case Controller::Mode::POLYGON:
+            break;
+        case Controller::Mode::LIGHT:
+            if (!controller->GetLightSources().empty()) {
+                controller->UpdateLightSourcePosition(0, pos);
+            }
+            break;
+        case Controller::Mode::STATIC_LIGHTS:
+            break;
+    }
+    update();
+}
+
+void DrawingArea::mouseReleaseEvent(QMouseEvent *event)
+{
+    if (!controller) return;
+    switch (mode) {
+        case Controller::Mode::POLYGON:
+            break;
+        case Controller::Mode::LIGHT:
+            break;
+        case Controller::Mode::STATIC_LIGHTS:
+            break;
+    }
+    update();
+}
+
+bool DrawingArea::hasSelfIntersections(const std::vector<QPointF>& polygon) const
+{
+    if (polygon.size() < 3) return false;
+    for (size_t i = 0; i < polygon.size(); ++i) {
+        const QPointF& p1 = polygon[i];
+        const QPointF& p2 = polygon[(i + 1) % polygon.size()];
+        for (size_t j = i + 2; j < polygon.size(); ++j) {
+            const QPointF& p3 = polygon[j];
+            const QPointF& p4 = polygon[(j + 1) % polygon.size()];
+            if (doSegmentsIntersect(p1, p2, p3, p4)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool DrawingArea::polygonsIntersect(const std::vector<QPointF>& poly1, const std::vector<QPointF>& poly2) const
+{
+    for (size_t i = 0; i < poly1.size(); ++i) {
+        const QPointF& p1 = poly1[i];
+        const QPointF& p2 = poly1[(i + 1) % poly1.size()];
+        for (size_t j = 0; j < poly2.size(); ++j) {
+            const QPointF& p3 = poly2[j];
+            const QPointF& p4 = poly2[(j + 1) % poly2.size()];
+            if (doSegmentsIntersect(p1, p2, p3, p4)) {
+                return true;
+            }
+        }
+    }
+    if (isPointInPolygon(poly1[0], poly2) || isPointInPolygon(poly2[0], poly1)) {
+        return true;
+    }
+    return false;
+}
+
+bool DrawingArea::doSegmentsIntersect(const QPointF& p1, const QPointF& p2, const QPointF& p3, const QPointF& p4) const
+{
+    auto orientation = [](const QPointF& a, const QPointF& b, const QPointF& c) {
+        double val = (b.y() - a.y()) * (c.x() - b.x()) - (b.x() - a.x()) * (c.y() - b.y());
+        if (val == 0) return 0;
+        return (val > 0) ? 1 : 2;
+    };
+    auto onSegment = [](const QPointF& p, const QPointF& q, const QPointF& r) {
+        return q.x() <= std::max(p.x(), r.x()) && q.x() >= std::min(p.x(), r.x()) &&
+               q.y() <= std::max(p.y(), r.y()) && q.y() >= std::min(p.y(), r.y());
+    };
+    int o1 = orientation(p1, p2, p3);
+    int o2 = orientation(p1, p2, p4);
+    int o3 = orientation(p3, p4, p1);
+    int o4 = orientation(p3, p4, p2);
+    if (o1 != o2 && o3 != o4) return true;
+    if (o1 == 0 && onSegment(p1, p3, p2)) return true;
+    if (o2 == 0 && onSegment(p1, p4, p2)) return true;
+    if (o3 == 0 && onSegment(p3, p1, p4)) return true;
+    if (o4 == 0 && onSegment(p3, p2, p4)) return true;
+    return false;
+}
+
+bool DrawingArea::isPointInPolygon(const QPointF& point, const std::vector<QPointF>& polygon) const
+{
+    if (polygon.size() < 3) return false;
+    bool inside = false;
+    for (size_t i = 0, j = polygon.size() - 1; i < polygon.size(); j = i++) {
+        if (((polygon[i].y() > point.y()) != (polygon[j].y() > point.y())) &&
+            (point.x() < (polygon[j].x() - polygon[i].x()) * (point.y() - polygon[i].y()) /
+                        (polygon[j].y() - polygon[i].y()) + polygon[i].x())) {
+            inside = !inside;
+        }
+    }
+    return inside;
+}
+
+void DrawingArea::onRadiusChanged(int value)
+{
+    if (controller && selectedLightIndex < controller->GetLightSources().size()) {
+        controller->UpdateStaticLightRadius(selectedLightIndex, value);
+    }
+}
+
+void DrawingArea::CancelPolygonDrawing()
+{
+    isDrawingPolygon = false;
+    updateBackgroundCache();
+    update();
+}

--- a/labs/raycaster/src/main.cpp
+++ b/labs/raycaster/src/main.cpp
@@ -1,0 +1,12 @@
+#include "mainwindow.h"
+#include <QApplication>
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    MainWindow window;
+    window.setAttribute(Qt::WA_OpaquePaintEvent);
+    window.setAttribute(Qt::WA_NoSystemBackground);
+    window.show();
+    return app.exec();
+}

--- a/labs/raycaster/src/mainwindow.cpp
+++ b/labs/raycaster/src/mainwindow.cpp
@@ -1,0 +1,122 @@
+#include "mainwindow.h"
+#include "drawingarea.h"
+#include "controller.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QCheckBox>
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+    , drawingArea(nullptr)
+    , controller(nullptr)
+{
+    controller = new Controller(this);
+    setupUI();
+}
+
+MainWindow::~MainWindow()
+{
+}
+
+void MainWindow::setupUI()
+{
+    centralWidget = new QWidget(this);
+    mainLayout = new QVBoxLayout(centralWidget);
+    mainLayout->setSpacing(10);
+    mainLayout->setContentsMargins(10, 10, 10, 10);
+
+    modeButtonsLayout = new QHBoxLayout();
+    modeButtonsLayout->setSpacing(10);
+    createModeButtons();
+    mainLayout->addLayout(modeButtonsLayout);
+
+    drawingArea = new DrawingArea(centralWidget);
+    drawingArea->setController(controller);
+    mainLayout->addWidget(drawingArea);
+
+    utilityButtonsLayout = new QHBoxLayout();
+    utilityButtonsLayout->setSpacing(10);
+    createUtilityButtons();
+    mainLayout->addLayout(utilityButtonsLayout);
+
+    setCentralWidget(centralWidget);
+    resize(800, 600);
+}
+
+void MainWindow::createModeButtons()
+{
+    polygonModeButton = new QPushButton("Polygon Mode", centralWidget);
+    lightModeButton = new QPushButton("Light Mode", centralWidget);
+    staticLightsModeButton = new QPushButton("Static Lights", centralWidget);
+
+    lightModeButton->setChecked(true);
+
+    modeButtonsLayout->addWidget(polygonModeButton);
+    modeButtonsLayout->addWidget(lightModeButton);
+    modeButtonsLayout->addWidget(staticLightsModeButton);
+
+    connect(polygonModeButton, &QPushButton::clicked, this, &MainWindow::onPolygonModeClicked);
+    connect(lightModeButton, &QPushButton::clicked, this, &MainWindow::onLightModeClicked);
+    connect(staticLightsModeButton, &QPushButton::clicked, this, &MainWindow::onStaticLightsModeClicked);
+}
+
+void MainWindow::createUtilityButtons()
+{
+    clearPolygonsButton = new QPushButton("Clear Polygons", centralWidget);
+    clearStaticLightsButton = new QPushButton("Clear Static Lights", centralWidget);
+    dynamicLightCollisionsCheckbox = new QCheckBox("Dynamic Light Collisions", centralWidget);
+    dynamicLightCollisionsCheckbox->setChecked(true);
+
+    utilityButtonsLayout->addWidget(clearPolygonsButton);
+    utilityButtonsLayout->addWidget(clearStaticLightsButton);
+    utilityButtonsLayout->addWidget(dynamicLightCollisionsCheckbox);
+
+    connect(clearPolygonsButton, &QPushButton::clicked, this, &MainWindow::onClearPolygonsClicked);
+    connect(clearStaticLightsButton, &QPushButton::clicked, this, &MainWindow::onClearStaticLightsClicked);
+    connect(dynamicLightCollisionsCheckbox, &QCheckBox::stateChanged, this, &MainWindow::onDynamicLightCollisionsChanged);
+}
+
+void MainWindow::onPolygonModeClicked()
+{
+    controller->setMode(Controller::Mode::POLYGON);
+    drawingArea->setMode(Controller::Mode::POLYGON);
+}
+
+void MainWindow::onLightModeClicked()
+{
+    controller->setMode(Controller::Mode::LIGHT);
+    drawingArea->setMode(Controller::Mode::LIGHT);
+}
+
+void MainWindow::onStaticLightsModeClicked()
+{
+    controller->setMode(Controller::Mode::STATIC_LIGHTS);
+    drawingArea->setMode(Controller::Mode::STATIC_LIGHTS);
+}
+
+void MainWindow::onClearPolygonsClicked()
+{
+    while (controller->GetPolygons().size() > 1) {
+        controller->RemoveLastPolygon();
+    }
+    drawingArea->CancelPolygonDrawing();
+    drawingArea->updateBackgroundCache();
+    drawingArea->update();
+}
+
+void MainWindow::onClearStaticLightsClicked()
+{
+    auto& lightSources = controller->GetLightSources();
+    for (size_t i = lightSources.size(); i > 0; --i) {
+        if (lightSources[i-1].isStatic) {
+            controller->RemoveLightSource(i-1);
+        }
+    }
+    drawingArea->update();
+}
+
+void MainWindow::onDynamicLightCollisionsChanged(int state)
+{
+    controller->SetDynamicLightCollisions(state == Qt::Checked);
+}


### PR DESCRIPTION
To run: `bazel run //labs/raycaster`

Modes:
- Polygon Mode: LMB to create a new polygon and add vertices to it. RMB to connect points. Intersecting polygons are not allowed, but you can create polygons inside other polygons.
- Light Mode: The default mode (raycaster).
- Static Lights: LMB to add a static light. Use the slider to adjust the radius of the last added light. 

Buttons:
- Clear Polygons – deletes all polygons.
- Clear Static Lights – deletes all static lights.
- Collision Checkbox – toggles collision for the dynamic light source with polygons.